### PR TITLE
Melon loader0.6.0 

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -6,8 +6,8 @@ using MelonLoader;
 // La información general de un ensamblado se controla mediante el siguiente 
 // conjunto de atributos. Cambie estos valores de atributo para modificar la información
 // asociada con un ensamblado.
-[assembly: MelonModInfo(typeof(WeightTweaks.WeightTweaks), "Weight Tweaks", "2.0", "Xpazeman")]
-[assembly: MelonModGame("Hinterland", "TheLongDark")]
+[assembly: MelonInfo(typeof(WeightTweaks.WeightTweaks), "Weight Tweaks", "2.0", "Xpazeman")]
+[assembly: MelonGame("Hinterland", "TheLongDark")]
 [assembly: AssemblyTitle("tld-weight-tweaks")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]

--- a/WeightTweaks.csproj
+++ b/WeightTweaks.csproj
@@ -1,89 +1,57 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C68C54DB-0BB7-4418-8C6C-00B15B04C6AA}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>WeightTweaks</RootNamespace>
-    <AssemblyName>WeightTweaks</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=1.0.6955.36066, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Il2Cppmscorlib">
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>
-    </Reference>
-    <Reference Include="Il2CppSystem">
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\Managed\Il2CppSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="MelonLoader.ModHandler">
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\MelonLoader.ModHandler.dll</HintPath>
-    </Reference>
-    <Reference Include="ModSettings, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\Mods\ModSettings.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnhollowerBaseLib, Version=0.4.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\Managed\UnhollowerBaseLib.dll</HintPath>
-    </Reference>
-    <Reference Include="UnhollowerRuntimeLib, Version=0.4.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\Managed\UnhollowerRuntimeLib.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\TheLongDark\MelonLoader\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="src\Patches.cs" />
-    <Compile Include="src\WeightTweaks.cs" />
-    <Compile Include="src\WeightTweaksSettings.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="README.md" />
-  </ItemGroup>
-  <ItemGroup>
-    <WCFMetadata Include="Connected Services\" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<!--This is an xml comment. Comments have no impact on compiling.-->
+
+	<PropertyGroup>
+		<!--This needs to be changed for the mod to compile.-->
+		<TheLongDarkPath>C:\Program Files (x86)\Steam\steamapps\common\TheLongDark</TheLongDarkPath>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<!--This is the .NET version the mod will be compiled with. Don't change it.-->
+		<TargetFramework>net6.0</TargetFramework>
+
+		<!--This tells the compiler to use the latest C# version.-->
+		<LangVersion>Latest</LangVersion>
+
+		<!--This adds global usings for a few common System namespaces.-->
+		<ImplicitUsings>enable</ImplicitUsings>
+
+		<!--This enables nullable annotation and analysis. It's good coding form.-->
+		<Nullable>enable</Nullable>
+
+		<!--This tells the compiler to use assembly attributes instead of generating its own.-->
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+		<!--PDB files are mostly useless for modding since they can't be loaded.-->
+		<DebugType>none</DebugType>
+	</PropertyGroup>
+
+	<!--This tells the compiler where to look for assemblies. Don't change it.-->
+	<PropertyGroup>
+		<MelonLoaderPath>$(TheLongDarkPath)/MelonLoader/net6</MelonLoaderPath>
+		<ManagedPath>$(TheLongDarkPath)/MelonLoader/Managed</ManagedPath>
+		<Il2CppPath>$(TheLongDarkPath)/MelonLoader/Il2CppAssemblies</Il2CppPath>
+		<ModsPath>$(TheLongDarkPath)/Mods</ModsPath>
+		<AssemblySearchPaths>$(AssemblySearchPaths);$(MelonLoaderPath);$(ManagedPath);$(Il2CppPath);$(ModsPath);</AssemblySearchPaths>
+	</PropertyGroup>
+
+	<!--This tells the compiler to not include referenced assemblies in the output folder.-->
+	<ItemDefinitionGroup>
+		<Reference>
+			<Private>False</Private>
+		</Reference>
+	</ItemDefinitionGroup>
+
+	<!--This is the list of assemblies that the mod references. Most of these are unnecessary for normal mods, but are included here for completeness.-->
+	<ItemGroup>
+		<Reference Include="MelonLoader"/>
+		<Reference Include="0Harmony"/>
+		<Reference Include="Il2CppInterop.Common"/>
+		<Reference Include="Il2CppInterop.Runtime"/>
+		<Reference Include="Assembly-CSharp"/>
+		<Reference Include="Il2Cppmscorlib"/>
+		<Reference Include="Il2CppSystem"/>
+		<Reference Include="UnityEngine.CoreModule"/>
+		<Reference Include="ModSettings"/>
+	</ItemGroup>
 </Project>

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -22,7 +22,7 @@ namespace WeightTweaks
         }
     }
 
-    [HarmonyPatch(typeof(GearItem), "GetItemWeightKG")]
+    [HarmonyPatch(typeof(GearItem), "GetItemWeightKG", new Type[] { typeof(bool) })]
     internal class GearItem_GetItemWeightKG
     {
         private static void Postfix(GearItem __instance, ref float __result)

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Harmony;
+using HarmonyLib;
+using Il2Cpp;
 using UnityEngine;
 
 namespace WeightTweaks

--- a/src/WeightTweaks.cs
+++ b/src/WeightTweaks.cs
@@ -1,7 +1,7 @@
-﻿using System.IO;
 using System.Reflection;
 using UnityEngine;
 using MelonLoader;
+using Il2Cpp;
 
 namespace WeightTweaks
 {


### PR DESCRIPTION
Builds and works except "GetItemWeightIgnoreClothingWornBonusKG" see below.
(a little beyond my knowledge right now)

[17:41:02.085] [Weight_Tweaks] HarmonyLib.HarmonyException: Patching exception in method null
 ---> System.ArgumentException: Undefined target method for patch method static void WeightTweaks.GearItem_GetItemWeightIgnoreClothingWornBonusKG::Postfix(Il2Cpp.GearItem __instance, Single& __result)
   at HarmonyLib.PatchClassProcessor.PatchWithAttributes(MethodBase& lastOriginal)
   at HarmonyLib.PatchClassProcessor.Patch()
   --- End of inner exception stack trace ---
   at HarmonyLib.PatchClassProcessor.ReportException(Exception exception, MethodBase original)
   at HarmonyLib.PatchClassProcessor.Patch()
   at HarmonyLib.Harmony.<PatchAll>b__11_0(Type type)
   at HarmonyLib.CollectionExtensions.Do[T](IEnumerable`1 sequence, Action`1 action)
   at HarmonyLib.Harmony.PatchAll(Assembly assembly)
   at MelonLoader.MelonMod.HarmonyInit() in D:\a\MelonLoader\MelonLoader\MelonLoader\Melons\MelonMod.cs:line 40
   at MelonLoader.MelonEvent.<>c.<Invoke>b__1_0(LemonAction x) in D:\a\MelonLoader\MelonLoader\MelonLoader\Melons\Events\MelonEvent.cs:line 174
   at MelonLoader.MelonEventBase`1.Invoke(Action`1 delegateInvoker) in D:\a\MelonLoader\MelonLoader\MelonLoader\Melons\Events\MelonEvent.cs:line 143